### PR TITLE
feat: collapse expanded quiz panel when clicking explain (#30)

### DIFF
--- a/frontend/src/components/studio/StudioQuizApp.tsx
+++ b/frontend/src/components/studio/StudioQuizApp.tsx
@@ -16,11 +16,11 @@ interface StudioQuizAppProps {
   onSendMessage?: (message: string) => void;
 }
 
-export function StudioQuizApp({ 
-  conversationId, 
+export function StudioQuizApp({
+  conversationId,
   conversationTitle,
   sourceCount,
-  onSendMessage 
+  onSendMessage
 }: StudioQuizAppProps) {
   const {
     questions,
@@ -155,6 +155,11 @@ Help me understand why my answer was incorrect.`;
     });
 
     onSendMessage?.(explainMessage);
+
+    // Collapse the quiz panel if it's expanded so the user can see the explanation in the chat
+    if (isQuizExpanded) {
+      setIsQuizExpanded(false);
+    }
   };
 
   const getOptionStyles = (optionIndex: number) => {
@@ -183,7 +188,7 @@ Help me understand why my answer was incorrect.`;
   // Render text with LaTeX
   const renderText = (text: string) => {
     const parts = renderWithLatex(text);
-    return parts.map((part, idx) => 
+    return parts.map((part, idx) =>
       typeof part === 'string' ? <span key={idx}>{part}</span> : part
     );
   };
@@ -251,9 +256,8 @@ Help me understand why my answer was incorrect.`;
                   key={index}
                   onClick={() => handleOptionClick(index)}
                   disabled={hasAnswered || isSubmitting}
-                  className={`w-full flex items-center gap-3 p-4 rounded-xl border-2 transition-all text-left ${getOptionStyles(index)} ${
-                    !hasAnswered && !isSubmitting ? 'cursor-pointer' : 'cursor-default'
-                  } focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2`}
+                  className={`w-full flex items-center gap-3 p-4 rounded-xl border-2 transition-all text-left ${getOptionStyles(index)} ${!hasAnswered && !isSubmitting ? 'cursor-pointer' : 'cursor-default'
+                    } focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2`}
                 >
                   <span className="shrink-0 text-gray-500 dark:text-gray-400 font-medium">
                     {String.fromCharCode(65 + index)}.


### PR DESCRIPTION
# Fix: Improve UX Flow for Quiz Explanation (#30)

## Description
This PR addresses **Issue #30** by improving the UX flow when a user requests an explanation for an incorrect quiz answer.

Previously, when the quiz was in **Expanded (Full-screen) Mode**, clicking **"Explain"** sent a message to the chat behind the quiz panel. As a result, the user could not see the AI’s response without manually collapsing the panel.

Now, when **"Explain"** is clicked, the expanded quiz panel automatically collapses to the sidebar so the user can immediately view the streaming explanation in the chat interface.

---

## ✅ Features / Fixes Implemented

- **Automatic Collapse**  
  Implemented logic in `StudioQuizApp.tsx` inside `handleExplain` to reset `isQuizExpanded` to `false`.

- **Smart Trigger**  
  The collapse only occurs if the quiz panel is currently expanded, preventing unnecessary state updates for users already in sidebar mode.

- **Context Continuity**  
  Verified that the context-aware **"Explain"** message is still correctly sent to the `onSendMessage` handler and appears in the chat.

- **UX Parity**  
  Ensures the **"Explain"** action works seamlessly across all quiz view modes:
  - Mini mode
  - Sidebar mode
  - Expanded mode

---

## 🧪 Testing

- **Mock Data Validation**  
  Used temporary mock conversation and quiz data to simulate a full quiz session.

- **Expanded Mode Test**  
  Verified that clicking **"Explain"** in full-screen mode collapses the panel and reveals the chat explanation.

- **Sidebar Mode Test**  
  Verified that clicking **"Explain"** in sidebar mode keeps the UI stable and continues functioning normally.

- **Clean State**  
  Confirmed all temporary mock testing code was removed before submission.

---

## 📸 Screenshots
![verify_collapse_fix_with_mock_1772637731456_1772676062061](https://github.com/user-attachments/assets/3d816f13-ae68-42b3-a80f-8b35121c48d3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quiz panel now automatically collapses after submitting an explain message when previously expanded, improving the quiz flow user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->