### PR TITLE
Add chat message validation

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
   "type": "commonjs",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "npm run test:chat-validation",
+    "test:chat-validation": "node --test -r ts-node/register src/utils/chat-message-validation.test.ts",
     "dev": "npm run db:migrate && nodemon --exec ts-node src/index.ts",
     "build": "tsc",
     "start": "npm run db:migrate && node dist/index.js",

--- a/backend/src/controllers/chat.controller.ts
+++ b/backend/src/controllers/chat.controller.ts
@@ -12,8 +12,13 @@ import {
     UpdateConversationResponse
 } from '../types/chat.types';
 import { createLogger } from '../utils/logger';
+import {
+    createChatMessageRateLimiter,
+    validateChatMessage
+} from '../utils/chat-message-validation';
 
 const logger = createLogger('CHAT-CONTROLLER');
+const chatMessageRateLimiter = createChatMessageRateLimiter();
 
 export class ChatController {
     /**
@@ -35,9 +40,21 @@ export class ChatController {
 
             logger.info(`Starting new conversation for ${sourceIds.length} source(s): ${sourceIds.join(', ')}${title ? ` with title: "${title}"` : ''}`);
 
+            const sanitizedInitialMessage = initialMessage === undefined
+                ? undefined
+                : validateChatMessage(initialMessage);
+
+            if (sanitizedInitialMessage && !sanitizedInitialMessage.valid) {
+                res.status(400).json({
+                    success: false,
+                    error: sanitizedInitialMessage.error
+                } as StartConversationResponse);
+                return;
+            }
+
             const { conversation, initialMessages } = await ChatService.createConversation({
                 sourceIds,
-                initialMessage,
+                initialMessage: sanitizedInitialMessage?.message,
                 title
             });
 
@@ -74,20 +91,30 @@ export class ChatController {
                 return;
             }
 
-            if (!message || message.trim() === '') {
+            const validatedMessage = validateChatMessage(message);
+            if (!validatedMessage.valid) {
                 res.status(400).json({
                     success: false,
-                    error: 'Message is required'
+                    error: validatedMessage.error
+                } as SendMessageResponse);
+                return;
+            }
+
+            const rateLimit = chatMessageRateLimiter.check(`${req.ip}:${conversationId}`);
+            if (!rateLimit.allowed) {
+                res.status(429).json({
+                    success: false,
+                    error: rateLimit.error
                 } as SendMessageResponse);
                 return;
             }
 
             logger.info(`Sending message to conversation: ${conversationId}`);
-            logger.info(`Message: ${message}`);
+            logger.info(`Message length: ${validatedMessage.message.length}`);
 
             const request: SendMessageRequest = {
                 conversationId,
-                message: message.trim()
+                message: validatedMessage.message
             };
 
             const result = await ChatService.sendMessage(request);

--- a/backend/src/sockets/chat.socket.ts
+++ b/backend/src/sockets/chat.socket.ts
@@ -6,8 +6,13 @@
 import { Server, Socket } from 'socket.io';
 import { streamChatGraphWithWebSocket } from '../services/chat-stream.service';
 import { createLogger } from '../utils/logger';
+import {
+    createChatMessageRateLimiter,
+    validateChatMessage
+} from '../utils/chat-message-validation';
 
 const logger = createLogger('CHAT-SOCKET');
+const chatMessageRateLimiter = createChatMessageRateLimiter();
 
 /**
  * Setup chat WebSocket handlers
@@ -44,12 +49,24 @@ export function setupChatSocket(io: Server): void {
          * Send message and stream response
          * Client emits: { conversationId: string, message: string }
          */
-        socket.on('send_message', async (data: { conversationId: string; message: string }) => {
+        socket.on('send_message', async (data: { conversationId?: string; message?: unknown } = {}) => {
             try {
                 const { conversationId, message } = data;
 
-                if (!conversationId || !message) {
+                if (!conversationId) {
                     socket.emit('error', { message: 'conversationId and message are required' });
+                    return;
+                }
+
+                const validatedMessage = validateChatMessage(message);
+                if (!validatedMessage.valid) {
+                    socket.emit('error', { conversationId, message: validatedMessage.error });
+                    return;
+                }
+
+                const rateLimit = chatMessageRateLimiter.check(`${socket.handshake.address}:${conversationId}`);
+                if (!rateLimit.allowed) {
+                    socket.emit('error', { conversationId, message: rateLimit.error });
                     return;
                 }
 
@@ -59,7 +76,7 @@ export function setupChatSocket(io: Server): void {
                 socket.emit('message_start', { conversationId });
 
                 // Stream the chat graph execution
-                await streamChatGraphWithWebSocket(conversationId, message, socket);
+                await streamChatGraphWithWebSocket(conversationId, validatedMessage.message, socket);
 
             } catch (error) {
                 logger.error(`[CHAT-SOCKET] Error processing message: ${error}`);

--- a/backend/src/utils/chat-message-validation.test.ts
+++ b/backend/src/utils/chat-message-validation.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    createChatMessageRateLimiter,
+    MAX_CHAT_MESSAGE_LENGTH,
+    validateChatMessage
+} from './chat-message-validation';
+
+test('accepts and trims a valid chat message', () => {
+    const result = validateChatMessage('  Explain photosynthesis  ');
+
+    assert.equal(result.valid, true);
+    if (result.valid) {
+        assert.equal(result.message, 'Explain photosynthesis');
+    }
+});
+
+test('rejects empty and whitespace-only messages', () => {
+    assert.deepEqual(validateChatMessage('').valid, false);
+    assert.deepEqual(validateChatMessage('   \n\t  ').valid, false);
+});
+
+test('rejects non-string messages', () => {
+    const result = validateChatMessage(null);
+
+    assert.equal(result.valid, false);
+    if (!result.valid) {
+        assert.equal(result.error, 'Message must be a string');
+    }
+});
+
+test('removes script blocks and html tags before accepting a message', () => {
+    const result = validateChatMessage('<p>Hello</p><script>alert("x")</script><strong>world</strong>');
+
+    assert.equal(result.valid, true);
+    if (result.valid) {
+        assert.equal(result.message, 'Hello world');
+    }
+});
+
+test('rejects messages longer than the maximum length after sanitization', () => {
+    const result = validateChatMessage('a'.repeat(MAX_CHAT_MESSAGE_LENGTH + 1));
+
+    assert.equal(result.valid, false);
+    if (!result.valid) {
+        assert.equal(result.error, `Message must be ${MAX_CHAT_MESSAGE_LENGTH} characters or fewer`);
+    }
+});
+
+test('rate limiter blocks messages over the configured fixed window limit', () => {
+    const limiter = createChatMessageRateLimiter({ maxMessages: 2, windowMs: 1000 });
+
+    assert.equal(limiter.check('user-1', 100).allowed, true);
+    assert.equal(limiter.check('user-1', 200).allowed, true);
+    assert.equal(limiter.check('user-1', 300).allowed, false);
+    assert.equal(limiter.check('user-1', 1200).allowed, true);
+});

--- a/backend/src/utils/chat-message-validation.ts
+++ b/backend/src/utils/chat-message-validation.ts
@@ -1,0 +1,85 @@
+export const MIN_CHAT_MESSAGE_LENGTH = 1;
+export const MAX_CHAT_MESSAGE_LENGTH = 4000;
+export const CHAT_MESSAGE_RATE_LIMIT_WINDOW_MS = 60_000;
+export const CHAT_MESSAGE_RATE_LIMIT_MAX = 30;
+
+type ChatMessageValidationResult =
+    | { valid: true; message: string }
+    | { valid: false; error: string };
+
+type ChatMessageRateLimitResult =
+    | { allowed: true }
+    | { allowed: false; error: string; retryAfterSeconds: number };
+
+interface ChatMessageRateLimitOptions {
+    maxMessages?: number;
+    windowMs?: number;
+}
+
+interface ChatMessageRateLimitBucket {
+    count: number;
+    resetAt: number;
+}
+
+const SCRIPT_OR_STYLE_BLOCK_PATTERN = /<\s*(script|style)\b[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/gi;
+const HTML_TAG_PATTERN = /<[^>]*>/g;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g;
+const WHITESPACE_PATTERN = /\s+/g;
+
+export function sanitizeChatMessage(message: string): string {
+    return message
+        .replace(SCRIPT_OR_STYLE_BLOCK_PATTERN, ' ')
+        .replace(HTML_TAG_PATTERN, ' ')
+        .replace(CONTROL_CHARACTER_PATTERN, '')
+        .replace(WHITESPACE_PATTERN, ' ')
+        .trim();
+}
+
+export function validateChatMessage(message: unknown): ChatMessageValidationResult {
+    if (typeof message !== 'string') {
+        return { valid: false, error: 'Message must be a string' };
+    }
+
+    const sanitizedMessage = sanitizeChatMessage(message);
+
+    if (sanitizedMessage.length < MIN_CHAT_MESSAGE_LENGTH) {
+        return { valid: false, error: 'Message is required' };
+    }
+
+    if (sanitizedMessage.length > MAX_CHAT_MESSAGE_LENGTH) {
+        return {
+            valid: false,
+            error: `Message must be ${MAX_CHAT_MESSAGE_LENGTH} characters or fewer`
+        };
+    }
+
+    return { valid: true, message: sanitizedMessage };
+}
+
+export function createChatMessageRateLimiter(options: ChatMessageRateLimitOptions = {}) {
+    const maxMessages = options.maxMessages ?? CHAT_MESSAGE_RATE_LIMIT_MAX;
+    const windowMs = options.windowMs ?? CHAT_MESSAGE_RATE_LIMIT_WINDOW_MS;
+    const buckets = new Map<string, ChatMessageRateLimitBucket>();
+
+    return {
+        check(identifier: string, now = Date.now()): ChatMessageRateLimitResult {
+            const bucket = buckets.get(identifier);
+
+            if (!bucket || now >= bucket.resetAt) {
+                buckets.set(identifier, { count: 1, resetAt: now + windowMs });
+                return { allowed: true };
+            }
+
+            if (bucket.count >= maxMessages) {
+                return {
+                    allowed: false,
+                    error: 'Too many chat messages. Please wait before sending another message.',
+                    retryAfterSeconds: Math.ceil((bucket.resetAt - now) / 1000)
+                };
+            }
+
+            bucket.count += 1;
+            return { allowed: true };
+        }
+    };
+}


### PR DESCRIPTION
## Summary
- Add a shared backend chat message guard for REST and WebSocket chat inputs.
- Reject non-string, empty/whitespace-only, and over-4000-character messages with clear errors.
- Strip HTML/script/style tags and control characters before messages reach the AI flow or database.
- Add a lightweight fixed-window limiter for chat sends.

## Security review
This narrows the input surface for chat by sanitizing user-controlled HTML/script content, avoiding raw message logging, and rate-limiting repeated chat sends to reduce abuse and model-cost risk. I kept it dependency-free so the behavior is easy to audit and does not add supply-chain surface.

## Validation
- npm run test:chat-validation
- npm run build

Fixes #51